### PR TITLE
Adding books to db

### DIFF
--- a/handlers/bookHandler.js
+++ b/handlers/bookHandler.js
@@ -1,4 +1,5 @@
 const axios = require(`axios`);
+const db = require(`../models`);
 
 const checkForISBN = (industryIdentifiers) => {
     //Goes through the data that google returned and searches if the book has an ISBN number tied to it
@@ -14,12 +15,29 @@ const checkForISBN = (industryIdentifiers) => {
     }
 };
 
+const checkDuplicate = async (bookTitle) => {
+    try {
+        const searchedBook = await db.Book.findOne({ title: bookTitle });
+        //If there is a group with that name return true
+        if (searchedBook !== null) {
+            return true
+        };
+    } catch (err) {
+        //TODO Something to show the error
+        console.log(err);
+    };
+};
+
 module.exports = {
     //All functions and files are singular on the back end
     //When searching google books spaces need to be turned into +
     searchGoogleBook: async (searchedBook) => {
-        const search = await axios.get(`https://www.googleapis.com/books/v1/volumes?q=${searchedBook}&maxResults=20&printType=Books`);
-
+        try {
+            const search = await axios.get(`https://www.googleapis.com/books/v1/volumes?q=${searchedBook}&maxResults=20&printType=Books`);
+        } catch (err) {
+            //TODO Add an error message here
+            return "Something went wrong"
+        }
 
         //TODO Try and do this in one ForEach or something
         const searchedBookArray = await search.data.items.filter(book => checkForISBN(book.volumeInfo.industryIdentifiers));
@@ -44,6 +62,24 @@ module.exports = {
         return returnedBookList;
     },
     saveBookToDB: async (savedBook) => {
-
+        //If the book is not a duplicate then save it to the database
+        if (!checkDuplicate(savedBook.title)) {
+            try {
+                const newBook = await db.Book.create(savedBook);
+                return newBook;
+            } catch (err) {
+                //TODO Add an error message here
+                return err;
+            };
+        } else {
+            //If the book is a duplicate, then get the book and return it to the user as if it was saved so they can then add it to the group
+            try {
+                const foundBook = await db.Book.findOne({ title: savedBook.title });
+                return foundBook;
+            } catch (err) {
+                //TODO Add an error message here
+                return err
+            }
+        };
     }
 };

--- a/handlers/bookHandler.js
+++ b/handlers/bookHandler.js
@@ -34,7 +34,7 @@ const checkDuplicate = async (fieldToCheck, valueToCheck, groupID) => {
             try {
                 const searchedGroup = await db.Group.findById([groupID]);
                 //If there is a book with that name return true
-                if (searchedGroup.currentBook === valueToCheck) {
+                if (searchedGroup.currentBook == valueToCheck) {
                     isDuplicate = true;
                 };
             } catch (err) {
@@ -102,7 +102,6 @@ module.exports = {
         };
     },
     updateCurrentBook: async (bookID, groupID) => {
-        console.log(bookID)
         //First grab the current book the group is going through
         const currentGroup = await db.Group.findById({ _id: groupID });
         //If there is no book in there just put the current book they selected into the app

--- a/handlers/groupHandler.js
+++ b/handlers/groupHandler.js
@@ -37,7 +37,7 @@ const checkDuplicate = async (checkedField, groupToSearch, userID) => {
 }
 
 module.exports = {
-    createGroup: async (userID, groupName, groupDescription, currentBook) => {
+    createGroup: async (userID, groupName, groupDescription) => {
         //Checks if there is already a group by that name
         //If there is return a bad status code which then can be used to display data to the user
         const isDuplicate = await checkDuplicate(`group`, groupName);
@@ -53,8 +53,7 @@ module.exports = {
                 isAdmin: true,
                 isMod: true,
                 isBanned: false
-            },
-            currentBook
+            }
         };
         const addedGroup = await db.Group.create(newGroup);
 
@@ -87,10 +86,5 @@ module.exports = {
         //Checks if that user is a mod and returns a boolean
         const isModerator = currentUser.isMod;
         return isModerator;
-    },
-    addNewBook: async (groupID, book) => {
-    },
-    searchForBook: async (book) => {
-        //Searches the database if the book has been saved before by ISBN
     }
 }

--- a/handlers/passport.js
+++ b/handlers/passport.js
@@ -171,7 +171,6 @@ module.exports = (passport) => {
 
                         //Add first time registerer from Facebook to local as well
                         newUser.local.username = profile.displayName;
-                        newUser.local.email = profile.emails[0].value;
 
                         //Save the new user to the database
                         newUser.save(err => {

--- a/models/Group.js
+++ b/models/Group.js
@@ -26,7 +26,9 @@ const GroupSchema = new Schema({
             }
         }
     ],
+    speed: String,
     currentBook: String, //This is going to be the id of the book which they searched
+    chapterForBook: Number,
     // Everything is singular
     //Array of books that this group has read in the past
     pastBook: [String]

--- a/models/index.js
+++ b/models/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     User: require(`./User`),
     Group: require(`./Group`),
-    Post: require(`./Post`)
+    Post: require(`./Post`),
+    Book: require(`./Book`)
 };

--- a/routes/groupRoutes.js
+++ b/routes/groupRoutes.js
@@ -66,14 +66,15 @@ module.exports = app => {
 
         const bookForGroup = await bookHandler.queryAndSaveToDB(chosenBook);
 
-
-        //TODO ADD BOOK TO GROUP
-        //First check if the user is a mod
-        //Take their current book and add it to the array of past books
-        //Take the bookForGroup and push it onto the group's current book
-        const updatedGroup = await bookHandler.updateCurrentBook(bookForGroup._id, groupID)
-
-        res.json(updatedGroup);
+        const isMod = await groupHandler.checkGroupMod(req.user._id, groupID);
+        if (isMod) {
+            const updatedGroup = await bookHandler.updateCurrentBook(bookForGroup._id, groupID);
+            res.json(updatedGroup);
+        } else {
+            //TODO Add something to show if they tried to add a book they weren't a mod for
+            res.json(`Moderator needed to update book`)
+            return
+        }
     })
 
     app.put(`/api/addbooktogroup`, userHandler.isLoggedIn, async (req, res) => {

--- a/routes/groupRoutes.js
+++ b/routes/groupRoutes.js
@@ -59,26 +59,28 @@ module.exports = app => {
         res.json(sortedPosts);
     });
 
-    app.post(`/api/addbooktodb`, userHandler.isLoggedIn, async (req, res) => {
+    //TODO CHECK IF USER IS MOD
+    app.post(`/api/addbook`, userHandler.isLoggedIn, async (req, res) => {
         //When the user picks a book from google books, this takes the data and saves it down
+        const { chosenBook, groupID } = req.body;
 
-        //The way it flows
-        //User creates a group
+        const bookForGroup = await bookHandler.queryAndSaveToDB(chosenBook);
 
-        //User adds users to the group
-        //User adds a book to the group
-        //      This splits into two steps, the user searches a book and adds it to the DB
-        //      The user adds the book chosen to the DB
-        const { chosenBook } = req.body;
 
-        const savedBook = await bookHandler.saveBookToDB(chosenBook);
+        //TODO ADD BOOK TO GROUP
+        //First check if the user is a mod
+        //Take their current book and add it to the array of past books
+        //Take the bookForGroup and push it onto the group's current book
+        const updatedGroup = await bookHandler.updateCurrentBook(bookForGroup._id, groupID)
 
-        res.json(savedBook);
+        res.json(updatedGroup);
     })
 
     app.put(`/api/addbooktogroup`, userHandler.isLoggedIn, async (req, res) => {
         //Should take a book chosen from google books and add it to the database
         //After the group is created the mod can add a book to the group
         //This route should also move a book to past books and put a new book in current book
+        const { bookForGroup } = req.body;
+        res.json(bookForGroup);
     });
 }


### PR DESCRIPTION
With this pull request users can now add books to the database if they don't already exist. It will go through and check if the title matches to a book already in the DB and use that one if it does.

Some changes with this
- Made it the same route for a user to add a book to the DB and add it to their group. 
- I did this so a user has to select a book once then it will check the DB if it already exists, if not it will go add it. Then it will assign it to the group as their current book.
- This will also push the current book into the past book array before overriding their current book and setting it to the new one.

Validation I put in with this request
- Books should not be duplicated in the database (this is based off name)
- A user cannot add a current book that is already in the current book space. They can however, re-read a book if they choose.
-- Example of this would be they choose Harry Potter, then choose War and Peace, and want to go back to Harry Potter after it will allow them. It will not allow them to choose Harry Potter twice