### PR TITLE
Updating benchmark

### DIFF
--- a/handlers/bookHandler.js
+++ b/handlers/bookHandler.js
@@ -123,7 +123,7 @@ module.exports = {
                 if (!isDuplicate) {
                     await db.Group.findByIdAndUpdate([groupID], { $push: { pastBook: currentGroup.currentBook } });
                     const updatedGroup = await db.Group.findByIdAndUpdate({ _id: groupID },
-                        { $set: { currentBook: bookID, currentBenchmark: 0, pageOrChapter: ``, totalPageOrChapter: 0 } },
+                        { $set: { currentBook: bookID, currentBenchmark: 0, pageOrChapter: ``, totalPageOrChapter: 0, previousBenchmark: [0] } },
                         { new: true });
                     return updatedGroup;
                 } else {

--- a/handlers/bookHandler.js
+++ b/handlers/bookHandler.js
@@ -123,7 +123,7 @@ module.exports = {
                 if (!isDuplicate) {
                     await db.Group.findByIdAndUpdate([groupID], { $push: { pastBook: currentGroup.currentBook } });
                     const updatedGroup = await db.Group.findByIdAndUpdate({ _id: groupID },
-                        { $set: { currentBook: bookID, currentBenchmark: 0, pageOrChapter: ``, totalPageOrChapter: 0, previousBenchmark: [0] } },
+                        { $set: { currentBook: bookID, currentBenchmark: 0, pageOrChapter: ``, totalPageOrChapter: 0, previousBenchmark: 0 } },
                         { new: true });
                     return updatedGroup;
                 } else {

--- a/handlers/groupHandler.js
+++ b/handlers/groupHandler.js
@@ -32,6 +32,13 @@ const checkDuplicate = async (checkedField, groupToSearch, userID) => {
                 console.log(err);
             };
             break;
+        case `benchmark`:
+            //Group to search here is the whole group
+            const benchmarkAlreadyCompleted = await groupToSearch.previousBenchmark.filter(benchmark => benchmark === checkedField);
+            if (benchmarkAlreadyCompleted > 0) {
+                result = true;
+            };
+            break;
     }
     return result;
 }
@@ -97,12 +104,16 @@ module.exports = {
         //Checks if the user is trying to set the benchmark higher than the total benchmarks
         const currentGroup = await db.Group.findById([groupID]);
 
+        const isDuplicate = await checkDuplicate(`benchmark`, currentGroup);
+
         if (+nextBenchmark <= +currentGroup.totalPageOrChapter) {
-            const updatedGroup = await db.Group.findByIdAndUpdate([groupID], { $set: { currentBenchmark: +nextBenchmark } }, { new: true });
-            return updatedGroup;
+            await db.Group.findByIdAndUpdate([groupID], { $set: { currentBenchmark: +nextBenchmark } }, { new: true });
+            if (isDuplicate) {
+
+            }
         } else {
             //TODO Proper error message
             return { 'error': `Cannot set a benchmark higher than the total benchmarks` };
-        }
+        };
     }
 }

--- a/handlers/groupHandler.js
+++ b/handlers/groupHandler.js
@@ -1,6 +1,6 @@
 const db = require(`../models`);
 
-const checkDuplicate = async (checkedField, groupToSearch, userID) => {
+const checkDuplicate = async (checkedField, groupToSearch, userID, nextBenchmark) => {
     let result = false;
     let searchedGroup;
     //TODO Do something other than log these errors
@@ -34,8 +34,9 @@ const checkDuplicate = async (checkedField, groupToSearch, userID) => {
             break;
         case `benchmark`:
             //Group to search here is the whole group
-            const benchmarkAlreadyCompleted = await groupToSearch.previousBenchmark.filter(benchmark => benchmark === checkedField);
-            if (benchmarkAlreadyCompleted > 0) {
+            const benchmarkAlreadyCompleted = await groupToSearch.previousBenchmark.filter(benchmark => benchmark == nextBenchmark);
+            console.log(benchmarkAlreadyCompleted)
+            if (benchmarkAlreadyCompleted.length !== 0) {
                 result = true;
             };
             break;
@@ -104,13 +105,15 @@ module.exports = {
         //Checks if the user is trying to set the benchmark higher than the total benchmarks
         const currentGroup = await db.Group.findById([groupID]);
 
-        const isDuplicate = await checkDuplicate(`benchmark`, currentGroup);
-
+        const isDuplicate = await checkDuplicate(`benchmark`, currentGroup, ``, currentGroup.currentBenchmark);
         if (+nextBenchmark <= +currentGroup.totalPageOrChapter) {
-            await db.Group.findByIdAndUpdate([groupID], { $set: { currentBenchmark: +nextBenchmark } }, { new: true });
-            if (isDuplicate) {
-
+            //If this benchmark hasn't been assigned before
+            //We keep track of this have posts associated to it
+            if (!isDuplicate) {
+                await db.Group.findByIdAndUpdate([groupID], { $push: { previousBenchmark: currentGroup.currentBenchmark } });
             }
+            const updatedGroup = await db.Group.findByIdAndUpdate([groupID], { $set: { currentBenchmark: +nextBenchmark } }, { new: true });
+            return updatedGroup;
         } else {
             //TODO Proper error message
             return { 'error': `Cannot set a benchmark higher than the total benchmarks` };

--- a/handlers/groupHandler.js
+++ b/handlers/groupHandler.js
@@ -82,7 +82,7 @@ module.exports = {
 
         };
         //get the user ID, add them to the array userlist within the group
-        const updatedGroup = await db.Group.update({ _id: groupID }, { $push: { userlist: newUser } }) //Must be an object as we store if they their permissions
+        const updatedGroup = await db.Group.update({ _id: groupID }, { $push: { userlist: newUser } }, { new: true }) //Must be an object as we store if they their permissions
         return updatedGroup;
     },
     checkGroupMod: async (userID, groupID) => {

--- a/handlers/postHandler.js
+++ b/handlers/postHandler.js
@@ -7,6 +7,7 @@ module.exports = {
             user: userID,
             group: groupID,
             date: Date.now(),
+            benchmark: userPost.benchmark,
             title: userPost.title,
             text: userPost.text,
             isSpoiler: userPost.isSpoiler

--- a/models/Group.js
+++ b/models/Group.js
@@ -32,6 +32,7 @@ const GroupSchema = new Schema({
     pageOrChapter: String,
     totalPageOrChapter: Number,
     currentBenchmark: Number,
+    previousBenchmark: [Number],
     // Everything is singular
     //Array of books that this group has read in the past
     pastBook: [String]

--- a/models/Post.js
+++ b/models/Post.js
@@ -10,7 +10,7 @@ const PostSchema = new Schema({
     title: String,
     text: String,
     isSpoiler: Boolean, //Determines if the post is a spoiler, something the user or admin can check when making it to hide by default
-    benchmark: String,
+    benchmark: Number,
     comment: [{
         user: String,
         text: String,


### PR DESCRIPTION
The groups now have benchmarks within the books

- Moderators are able to change the total amount of benchmarks that they want to set (either chapters or pages)
- They can update the benchmark to anything that they would like.
- Groups hold a list of previous benchmarks that were hit which can be used for posts

-- Need to talk about taking away pages, not quite sure how that would work