### PR TITLE
Update benchmark

### DIFF
--- a/client/src/componenets/GroupPage/CurrentBook.js
+++ b/client/src/componenets/GroupPage/CurrentBook.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import axios from 'axios';
 
 const initialState = {

--- a/client/src/componenets/GroupPage/UpdateBenchmark.js
+++ b/client/src/componenets/GroupPage/UpdateBenchmark.js
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import { withAuthorization } from '../Session';
+import axios from 'axios';
+
+const inputStyle = {
+    width: '50%',
+    height: '40px'
+}
+const labelStyle = {
+    marginBottom: '0px'
+}
+
+const initialState = {
+    currentBenchmark: null,
+    totalBenchmark: null,
+    error: null
+};
+
+class UpdateBenchmark extends Component {
+    constructor(props) {
+        super(props)
+        this.state = { ...initialState };
+    }
+
+    handleChange = event => {
+        this.setState({
+            [event.target.name]: event.target.value
+        })
+    }
+
+    handleSubmit = async event => {
+        console.log(`working`);
+    }
+
+    render() {
+        const { text, error } = this.state;
+
+        const isInvalid = text === '';
+
+        return (
+            <div>
+                <br />
+                {error && <p>{error.message}</p>}
+                <form className='form-horizontal' onSubmit={this.handleSubmit}>
+                    <div className='form-group'>
+                        <div className='col-1 col-ml-auto'>
+                            <label className='form-label' style={labelStyle} htmlFor='currentBenchmark'>Next Goal for Group:</label>
+                        </div>
+                        <div className='col-3 col-mr-auto'>
+                            <input className='form-input'
+                                style={inputStyle}
+                                type='number'
+                                name='currentBenchmark'
+                                placeholder='What is the next goal for the group?'
+                                value={this.state.currentBenchmark}
+                                onChange={this.handleChange}
+                            />
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <div className='col-1 col-ml-auto'>
+                            <label className='form-label' style={labelStyle} htmlFor='totalBenchmark'>Total Chapters:</label>
+                        </div>
+                        <div className='col-3 col-mr-auto'>
+                            <input className='form-input'
+                                style={inputStyle}
+                                type='totalBenchmark'
+                                name='number'
+                                placeholder='How Many Chapters for Your Book?'
+                                value={this.state.totalBenchmark}
+                                onChange={this.handleChange}
+                            />
+                        </div>
+                    </div>
+
+                    <div className='form-group '>
+                        <div className='col-7'></div>
+                        <button
+                            className='btn btn-primary col-1 col-mr-auto'
+                            disabled={isInvalid}
+                            type='submit'>Submit Post</button>
+                    </div>
+                </form>
+            </div>
+        );
+    };
+};
+
+
+const condition = authUser => !!authUser;
+
+export default withAuthorization(condition)(UpdateBenchmark);

--- a/client/src/componenets/GroupPage/UpdateBenchmark.js
+++ b/client/src/componenets/GroupPage/UpdateBenchmark.js
@@ -11,8 +11,8 @@ const labelStyle = {
 }
 
 const initialState = {
-    currentBenchmark: null,
-    totalBenchmark: null,
+    nextBenchmark: '',
+    totalBenchmark: '',
     error: null
 };
 
@@ -28,46 +28,81 @@ class UpdateBenchmark extends Component {
         })
     }
 
-    handleSubmit = async event => {
-        console.log(`working`);
+    handleCurrentSubmit = async event => {
+        event.preventDefault();
+
+        const nextBenchmark = +this.state.nextBenchmark;
+        const { groupID, isAdmin } = this.props;
+
+        try {
+            const dbResponse = await axios.put(`/api/updatebenchmark`, { nextBenchmark, groupID, isAdmin });
+        } catch (error) {
+            this.setState({ error: { message: `Moderator needed to update benchmark` } })
+        }
+    }
+
+    handleTotalSubmit = async event => {
+        event.preventDefault();
+
+        const totalCount = +this.state.totalBenchmark;
+        const { groupID, isAdmin } = this.props;
+
+        try {
+            const dbResponse = await axios.put(`/api/updatepagesetup`, { totalCount, groupID, isAdmin })
+        } catch (error) {
+            this.setState({ error: { message: `Moderator needed to update benchmark` } })
+        }
     }
 
     render() {
-        const { text, error } = this.state;
+        const { nextBenchmark, totalBenchmark, error } = this.state;
 
-        const isInvalid = text === '';
+        const currentIsInvalid = nextBenchmark === '' || nextBenchmark < 0;
+        const totalIsInvalid = totalBenchmark === '' || totalBenchmark < 0;
 
         return (
             <div>
                 <br />
                 {error && <p>{error.message}</p>}
-                <form className='form-horizontal' onSubmit={this.handleSubmit}>
+                <form className='form-horizontal' onSubmit={this.handleCurrentSubmit}>
                     <div className='form-group'>
                         <div className='col-1 col-ml-auto'>
-                            <label className='form-label' style={labelStyle} htmlFor='currentBenchmark'>Next Goal for Group:</label>
+                            <label className='form-label' style={labelStyle} htmlFor='nextBenchmark'>Next Goal for Group:</label>
                         </div>
                         <div className='col-3 col-mr-auto'>
                             <input className='form-input'
                                 style={inputStyle}
                                 type='number'
-                                name='currentBenchmark'
+                                name='nextBenchmark'
                                 placeholder='What is the next goal for the group?'
-                                value={this.state.currentBenchmark}
+                                value={this.state.nextBenchmark}
                                 onChange={this.handleChange}
                             />
                         </div>
                     </div>
 
+                    <div className='form-group '>
+                        <div className='col-7'></div>
+                        <button
+                            className='btn btn-primary col-1 col-mr-auto'
+                            disabled={currentIsInvalid}
+                            type='submit'>Set New Goal</button>
+                    </div>
+                </form>
+
+                <br />
+
+                <form className='form-horizontal' onSubmit={this.handleTotalSubmit}>
                     <div className='form-group'>
                         <div className='col-1 col-ml-auto'>
-                            <label className='form-label' style={labelStyle} htmlFor='totalBenchmark'>Total Chapters:</label>
+                            <label className='form-label' style={labelStyle} htmlFor='totalBenchmark'>Update Total Benchmarks / Chapters:</label>
                         </div>
                         <div className='col-3 col-mr-auto'>
                             <input className='form-input'
                                 style={inputStyle}
-                                type='totalBenchmark'
-                                name='number'
-                                placeholder='How Many Chapters for Your Book?'
+                                type='number'
+                                name='totalBenchmark'
+                                placeholder='What is the total benchmarks or chapters of this book?'
                                 value={this.state.totalBenchmark}
                                 onChange={this.handleChange}
                             />
@@ -78,8 +113,8 @@ class UpdateBenchmark extends Component {
                         <div className='col-7'></div>
                         <button
                             className='btn btn-primary col-1 col-mr-auto'
-                            disabled={isInvalid}
-                            type='submit'>Submit Post</button>
+                            disabled={totalIsInvalid}
+                            type='submit'>Update Total</button>
                     </div>
                 </form>
             </div>

--- a/client/src/componenets/GroupPage/index.js
+++ b/client/src/componenets/GroupPage/index.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import CurrentBook from './CurrentBook';
 import AddBook from './AddBook';
 import AddPost from './Discussion';
+import UpdateBenchmark from './UpdateBenchmark';
 
 
 const initialState = {
@@ -75,6 +76,7 @@ class GroupPage extends Component {
 
                 <AddBook groupID={groupID} isAdmin={isAdmin} />
                 {currentBook && <CurrentBook currentBook={currentBook} currentBenchmark={currentBenchmark} totalBenchmark={totalBenchmark} />}
+                {!totalBenchmark && <UpdateBenchmark />}
                 <GroupInfo groupName={groupName} groupDescription={groupDescription} />
                 <AddPost userID={this.props.userID} groupID={groupID} />
                 <img alt='Earthworm Jim and his book' src='../img/1550080499329.png' />

--- a/client/src/componenets/GroupPage/index.js
+++ b/client/src/componenets/GroupPage/index.js
@@ -83,7 +83,7 @@ class GroupPage extends Component {
 
                 <AddBook groupID={groupID} isAdmin={isAdmin} />
                 {currentBook && <CurrentBook currentBook={currentBook} currentBenchmark={currentBenchmark} totalBenchmark={totalBenchmark} />}
-                {!totalBenchmark && <UpdateBenchmark />}
+                <UpdateBenchmark isAdmin={isAdmin} groupID={groupID} />
                 <GroupInfo groupName={groupName} groupDescription={groupDescription} />
                 <AddPost userID={this.props.userID} groupID={groupID} />
                 <img alt='Earthworm Jim and his book' src='../img/1550080499329.png' />
@@ -92,11 +92,11 @@ class GroupPage extends Component {
     }
 }
 
-const GroupInfo = (params) => {
+const GroupInfo = (props) => {
     return (
         <Fragment>
-            <h3>Name: {params.groupName}</h3>
-            <p><strong>Description: </strong>{params.groupDescription}</p>
+            <h3>Name: {props.groupName}</h3>
+            <p><strong>Description: </strong>{props.groupDescription}</p>
         </Fragment>
     )
 }

--- a/handlers/groupHandler.js
+++ b/handlers/groupHandler.js
@@ -97,10 +97,10 @@ module.exports = {
         const isModerator = currentUser.isMod;
         return isModerator;
     },
-    setPageOrChapter: async (groupID, pageOrChapter, totalCount) => {
+    setPageOrChapter: async (groupID, totalCount) => {
         //This is hit after they check if the current user trying to make these changes is a mod
         //Also, should only be hit one time unless they go into the settings and change it
-        const updatedGroup = await db.Group.findByIdAndUpdate([groupID], { $set: { pageOrChapter: pageOrChapter, totalBenchmark: totalCount } },
+        const updatedGroup = await db.Group.findByIdAndUpdate([groupID], { $set: { totalBenchmark: totalCount } },
             { new: true })
         return updatedGroup;
     },
@@ -109,7 +109,8 @@ module.exports = {
         const currentGroup = await db.Group.findById([groupID]);
 
         const isDuplicate = await checkDuplicate(`benchmark`, currentGroup, ``, currentGroup.currentBenchmark);
-        if (+nextBenchmark <= +currentGroup.totalPageOrChapter) {
+
+        if (nextBenchmark <= currentGroup.totalBenchmark) {
             //If this benchmark hasn't been assigned before
             //We keep track of this have posts associated to it
             const lastBenchmark = currentGroup.currentBenchmark || 0;

--- a/routes/groupRoutes.js
+++ b/routes/groupRoutes.js
@@ -37,7 +37,7 @@ module.exports = app => {
 
     //Before post gets to here validate that there isn't a blank field
     app.post(`/api/newpost`, async (req, res) => {
-        const {userID, groupID, userPost } = req.body;
+        const { userID, groupID, userPost } = req.body;
 
         const newPost = await postHandler.createPost(userID, groupID, userPost);
         res.json(newPost);
@@ -74,12 +74,10 @@ module.exports = app => {
 
     //Adds the amount of pages or chapters to the Club
     app.put(`/api/updatepagesetup/`, async (req, res) => {
-        const { totalCount, pageOrChapter, groupID } = req.body;
+        const { totalCount, groupID, isAdmin } = req.body;
 
-        //Checks if the user is a mod of the group they're currently trying to update
-        const isMod = await groupHandler.checkGroupMod(req.user._id, groupID);
-        if (isMod) {
-            const updatedGroup = await groupHandler.setPageOrChapter(groupID, pageOrChapter, totalCount);
+        if (isAdmin) {
+            const updatedGroup = await groupHandler.setPageOrChapter(groupID, totalCount);
             res.json(updatedGroup);
         } else {
             //TODO Add something to show if they tried to update a group they weren't a mod for
@@ -88,18 +86,20 @@ module.exports = app => {
     });
 
     app.put(`/api/updatebenchmark`, async (req, res) => {
-        const { nextBenchmark, groupID } = req.body;
-
-        //TODO Check if the nextBenchmark is submitted as a number either here or before the route is hit
+        const { nextBenchmark, groupID, isAdmin } = req.body;
 
         //Checks if the user is a mod of the group they're currently trying to update
-        const isMod = await groupHandler.checkGroupMod(req.user._id, groupID);
-        if (isMod) {
+        if (isAdmin) {
+            //TODO if error returned show
             const updatedGroup = await groupHandler.updateBenchmark(groupID, nextBenchmark);
-            res.json(updatedGroup);
+            if (updatedGroup.error) {
+                res.status(501).send(updatedGroup)
+            } else {
+                res.status(200).send(updatedGroup);
+            }
         } else {
             //TODO Add something to show if they tried to update a group they weren't a mod for
-            res.json({ 'error': `Moderator needed to update book` });
+            res.json({ 'error': `Moderator needed to update benchmark` });
         };
 
     });


### PR DESCRIPTION
Users can now update the benchmarks both current and total.

These are broken out into two separate forms to keep everything simple in terms of submitting the data to the database.

I also had to make some changes to the back end to get rid of the passport stuff in there.